### PR TITLE
mt-02-38

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,3 +23,17 @@ describe('GET /api/cities', function () {
             })
     })
 })
+describe('GET /api/hotels', function () {
+
+    it('check status 404 when the filter does not find a hotel', function (done) {
+        request(app)
+            .get('/api/hotels/637a82b29ffbe50105832948')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err)
+                }
+                done()
+            })
+    })
+})


### PR DESCRIPTION
-  Verificacion de status 404 cuando el filtro no encuentra un _hotel_


EVIDENCIA: 

![image](https://user-images.githubusercontent.com/22920486/202923170-d88feb00-ebf1-4b25-ba21-aad6a6c6ecc9.png)
